### PR TITLE
Options to add additional imports for the output module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ purescript-derive-lenses < ./test-files/Data.Tree.purs > ./test-files/Lenses.pur
 Available options:
 ```
 --moduleName                  "Name of the output module"
---moduleImports               "Additional imports for the output module separated by | delimiter"
---moduleImportsDelimiter      "Delimiter of additional imports for the output module"
+--moduleImports               "List of additional imports for the output module"
 ```
 
 Using options:
 ```
-purescript-derive-lenses < ./test-files/Data.Tree.purs --moduleName My.Module --moduleImports "import A|import B" > ./test-files/Lenses.purs
+purescript-derive-lenses < ./test-files/Data.Tree.purs --moduleName My.Module --moduleImports "import A" --moduleImports "import B" > ./test-files/Lenses.purs
 ```
 
 
@@ -58,7 +57,6 @@ import Prelude as Prelude
 import Data.Lens as Lens
 import Data.Either as Either
 import Data.Tree
-import Data.Bar (Bar)
 
 
 foo :: forall a b r. Lens.Lens { "foo" :: a | r } { "foo" :: b | r } a b

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ A little utility to derive lenses and prisms for data types in PureScript
 
 Provide a PureScript module on standard input, and a new module will be returned on standard output
 
+Command:
+
+```
+purescript-derive-lenses < ./test-files/Data.Tree.purs > ./test-files/Lenses.purs
+```
+
+Available options:
+```
+--moduleName                  "Name of the output module"
+--moduleImports               "Additional imports for the output module separated by | delimiter"
+--moduleImportsDelimiter      "Delimiter of additional imports for the output module"
+```
+
+Using options:
+```
+purescript-derive-lenses < ./test-files/Data.Tree.purs --moduleName My.Module --moduleImports "import A|import B" > ./test-files/Lenses.purs
+```
+
+
 ## How it Works
 
 This tool generates the following types of optics:
@@ -14,6 +33,7 @@ This tool generates the following types of optics:
 - Lenses for object fields appearing in data constructors
 
 The generated lenses are compatible with the `purescript-profunctor-lenses` library.
+
 
 ## Example
 
@@ -38,6 +58,7 @@ import Prelude as Prelude
 import Data.Lens as Lens
 import Data.Either as Either
 import Data.Tree
+import Data.Bar (Bar)
 
 
 foo :: forall a b r. Lens.Lens { "foo" :: a | r } { "foo" :: b | r } a b

--- a/purescript-derive-lenses.cabal
+++ b/purescript-derive-lenses.cabal
@@ -13,7 +13,9 @@ cabal-version:       >=1.10
 executable purescript-derive-lenses
   main-is:             Main.hs
   build-depends:       base >=4.7 && <4.10,
+                       array,
                        boxes,
+                       split,
                        text,
                        optparse-generic ==1.1.*,
                        purescript >= 0.10.5

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,7 +5,7 @@
 
 module Main where
 
-import           Data.List.Split              (splitOn)
+-- import           Data.List.Split              (splitOn)
 import           Data.Maybe                   (fromMaybe, mapMaybe)
 import           Data.Text                    (pack, unpack)
 import qualified Language.PureScript          as P
@@ -17,15 +17,15 @@ import qualified Text.PrettyPrint.Boxes       as Box
 
 -- | Options for the command line interface
 data Options = Options
-  { moduleName             :: Maybe String
+  { moduleName    :: Maybe String
   -- ^ the name to use for the output module
-  , moduleImports          :: Maybe String
-  -- ^ additional imports for the output module
-  , moduleImportsDelimiter :: Maybe String
-  -- ^ delimiter of additional imports for the output module
+  , moduleImports :: [String]
+  -- ^ list of additional imports for the output module
   } deriving (Generic, Show)
 
 instance ParseRecord Options
+
+type Imports = [String]
 
 -- | An optic to be rendered during code generation.
 data Optic
@@ -148,10 +148,8 @@ app Options{..} input =
   where
     codeGen' sourceModule = codeGen
         (fromMaybe ((unpack . P.runModuleName) sourceModule ++ ".Lenses") moduleName)
-        moduleImports'
+        moduleImports
         sourceModule
-    delimiter = fromMaybe "|" moduleImportsDelimiter
-    moduleImports' = (++) (splitOn delimiter $ fromMaybe "" moduleImports) []
 
 -- | 'main' is a wrapper for the 'app' function
 main :: IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,7 +5,6 @@
 
 module Main where
 
--- import           Data.List.Split              (splitOn)
 import           Data.Maybe                   (fromMaybe, mapMaybe)
 import           Data.Text                    (pack, unpack)
 import qualified Language.PureScript          as P
@@ -24,8 +23,6 @@ data Options = Options
   } deriving (Generic, Show)
 
 instance ParseRecord Options
-
-type Imports = [String]
 
 -- | An optic to be rendered during code generation.
 data Optic

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,23 +1,28 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 
-import           Data.Maybe (fromMaybe, mapMaybe)
-import           Data.Text (pack, unpack)
-import qualified Language.PureScript as P
-import           Language.PureScript.Label (runLabel)
+import           Data.List.Split              (splitOn)
+import           Data.Maybe                   (fromMaybe, mapMaybe)
+import           Data.Text                    (pack, unpack)
+import qualified Language.PureScript          as P
+import           Language.PureScript.Label    (runLabel)
 import           Language.PureScript.PSString (decodeString)
-import           Options.Generic (Generic, ParseRecord, getRecord)
-import           Text.PrettyPrint.Boxes ((<>))
-import qualified Text.PrettyPrint.Boxes as Box
+import           Options.Generic              (Generic, ParseRecord, getRecord)
+import           Text.PrettyPrint.Boxes       ((<>))
+import qualified Text.PrettyPrint.Boxes       as Box
 
 -- | Options for the command line interface
 data Options = Options
-  { moduleName :: Maybe String
+  { moduleName             :: Maybe String
   -- ^ the name to use for the output module
+  , moduleImports          :: Maybe String
+  -- ^ additional imports for the output module
+  , moduleImportsDelimiter :: Maybe String
+  -- ^ delimiter of additional imports for the output module
   } deriving (Generic, Show)
 
 instance ParseRecord Options
@@ -65,8 +70,8 @@ process (P.Module _ _ mn ds _) =
     processDecl _ = []
 
 -- | Generate PureScript code for the output module.
-codeGen :: String -> P.ModuleName -> [Optic] -> Box.Box
-codeGen thisModule sourceModule = Box.vsep 1 Box.left . (preamble :) . map renderOptic
+codeGen :: String -> [String] -> P.ModuleName -> [Optic] -> Box.Box
+codeGen thisModule moduleImports sourceModule = Box.vsep 1 Box.left . (preamble :) . map renderOptic
   where
     preamble :: Box.Box
     preamble = Box.text . unlines $
@@ -76,7 +81,7 @@ codeGen thisModule sourceModule = Box.vsep 1 Box.left . (preamble :) . map rende
       , "import Data.Lens as Lens"
       , "import Data.Either as Either"
       , "import " ++ (unpack . P.runModuleName) sourceModule
-      ]
+      ] ++ moduleImports
 
     renderOptic :: Optic -> Box.Box
     renderOptic (DataMemberLens prop) = Box.vcat Box.left
@@ -141,7 +146,12 @@ app Options{..} input =
       Left errs -> show errs
       Right (_, m) -> (P.renderBox . uncurry codeGen' . process) m
   where
-    codeGen' sourceModule = codeGen (fromMaybe ((unpack . P.runModuleName) sourceModule ++ ".Lenses") moduleName) sourceModule
+    codeGen' sourceModule = codeGen
+        (fromMaybe ((unpack . P.runModuleName) sourceModule ++ ".Lenses") moduleName)
+        moduleImports'
+        sourceModule
+    delimiter = fromMaybe "|" moduleImportsDelimiter
+    moduleImports' = (++) (splitOn delimiter $ fromMaybe "" moduleImports) []
 
 -- | 'main' is a wrapper for the 'app' function
 main :: IO ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.25
+resolver: lts-7.18
 
 packages:
 - '.'


### PR DESCRIPTION
Options to generate additional imports for the output module:

```
--moduleImports               "List of additional imports for the output module "
```

An example is added to `README`.

_Update 02/03/2017:_ Remove need of `--moduleImportsDelimiter` Thx @alexbiehl for the hint!